### PR TITLE
Non preflight requests from unknown origins should not be rejected

### DIFF
--- a/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/CorsDirectives.scala
+++ b/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/CorsDirectives.scala
@@ -123,7 +123,7 @@ trait CorsDirectives {
             case None ⇒
               respondWithHeaders(responseHeaders) & provide(decorate)
             case invalidOrigin ⇒
-              reject(CorsRejection(invalidOrigin, None, None))
+              provide(decorate)
           }
 
         case _ if allowGenericHttpRequests ⇒


### PR DESCRIPTION
Fix for https://github.com/lomigmegard/akka-http-cors/issues/3