### PR TITLE
- bumped scala to 2.12.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val commonSettings = Seq(
   organization := "ch.megard",
   version := "0.1.9-SNAPSHOT",
   scalaVersion := "2.11.8",
-  crossScalaVersions := Seq(scalaVersion.value, "2.12.0-RC2"),
+  crossScalaVersions := Seq(scalaVersion.value, "2.12.0"),
   scalacOptions ++= Seq(
     "-unchecked",
     "-deprecation",
@@ -68,8 +68,8 @@ lazy val cors = Project(id = "akka-http-cors", base = file("akka-http-cors")).
   settings(commonSettings: _*).
   settings(publishSettings: _*).
   settings(
-    libraryDependencies += "com.typesafe.akka" %% "akka-http-experimental" % "2.4.11",
-    libraryDependencies += "com.typesafe.akka" %% "akka-http-testkit" % "2.4.11" % "test",
+    libraryDependencies += "com.typesafe.akka" %% "akka-http" % "10.0.0-RC2",
+    libraryDependencies += "com.typesafe.akka" %% "akka-http-testkit" % "10.0.0-RC2" % "test",
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.0" % "test"
   )
 


### PR DESCRIPTION
akka-http is undergoing some versioning changes (alongside a repo separation, see https://github.com/akka/akka-http/issues/3). OTOH, people may want to start using scala 2.12, hence this PR