### PR TITLE
Fix hyperlink couldn’t display correctly.

### DIFF
--- a/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/CorsDirectives.scala
+++ b/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/CorsDirectives.scala
@@ -13,8 +13,8 @@ import scala.collection.immutable.Seq
 /**
   * Provides directives that implement the CORS mechanism, enabling cross origin requests.
   *
-  * @see <a href="https://www.w3.org/TR/cors/">CORS W3C Recommendation</a>.
-  * @see <a href="https://www.ietf.org/rfc/rfc6454.txt">RFC 6454</a>.
+  * @see [[https://www.w3.org/TR/cors/ CORS W3C Recommendation]]
+  * @see [[https://www.ietf.org/rfc/rfc6454.txt RFC 6454]]
   *
   */
 trait CorsDirectives {

--- a/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/settings/CorsSettings.scala
+++ b/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/settings/CorsSettings.scala
@@ -36,7 +36,7 @@ abstract class CorsSettings extends javadsl.settings.CorsSettings {
     *
     * Default: `true`
     *
-    * @see <a href="https://www.w3.org/TR/cors/#access-control-allow-credentials-response-header">Access-Control-Allow-Credentials</a>
+    * @see [[https://www.w3.org/TR/cors/#access-control-allow-credentials-response-header Access-Control-Allow-Credentials]]
     */
   def allowCredentials: Boolean
 
@@ -52,7 +52,7 @@ abstract class CorsSettings extends javadsl.settings.CorsSettings {
     *
     * Default: `HttpOriginRange.*`
     *
-    * @see <a href="https://www.w3.org/TR/cors/#access-control-allow-origin-response-header">Access-Control-Allow-Origin</a>
+    * @see [[https://www.w3.org/TR/cors/#access-control-allow-origin-response-header Access-Control-Allow-Origin]]
     */
   def allowedOrigins: HttpOriginRange
 
@@ -64,7 +64,7 @@ abstract class CorsSettings extends javadsl.settings.CorsSettings {
     *
     * Default: `HttpHeaderRange.*`
     *
-    * @see <a href="https://www.w3.org/TR/cors/#access-control-allow-headers-response-header">Access-Control-Allow-Headers</a>
+    * @see [[https://www.w3.org/TR/cors/#access-control-allow-headers-response-header Access-Control-Allow-Headers]]
     */
   def allowedHeaders: HttpHeaderRange
 
@@ -77,7 +77,7 @@ abstract class CorsSettings extends javadsl.settings.CorsSettings {
     *
     * Default: `Seq(GET, POST, HEAD, OPTIONS)`
     *
-    * @see <a href="https://www.w3.org/TR/cors/#access-control-allow-methods-response-header">Access-Control-Allow-Methods</a>
+    * @see [[https://www.w3.org/TR/cors/#access-control-allow-methods-response-header Access-Control-Allow-Methods]]
     */
   def allowedMethods: Seq[HttpMethod]
 
@@ -88,8 +88,8 @@ abstract class CorsSettings extends javadsl.settings.CorsSettings {
     *
     * Default: `Seq.empty`
     *
-    * @see <a href="https://www.w3.org/TR/cors/#simple-response-header">Simple response headers</a>.
-    * @see <a href="https://www.w3.org/TR/cors/#access-control-expose-headers-response-header">Access-Control-Expose-Headers</a>
+    * @see [[https://www.w3.org/TR/cors/#simple-response-header Simple response headers]]
+    * @see [[https://www.w3.org/TR/cors/#access-control-expose-headers-response-header Access-Control-Expose-Headers]]
     */
   def exposedHeaders: Seq[String]
 
@@ -100,7 +100,7 @@ abstract class CorsSettings extends javadsl.settings.CorsSettings {
     *
     * Default: `Some(30 * 60)`
     *
-    * @see <a href="https://www.w3.org/TR/cors/#access-control-max-age-response-header">Access-Control-Max-Age</a>
+    * @see [[https://www.w3.org/TR/cors/#access-control-max-age-response-header Access-Control-Max-Age]]
     */
   def maxAge: Option[Long]
 


### PR DESCRIPTION
Hi @lomigmegard 

I changed the comments slightly, due to hyperlink couldn't display. I noticed that [CorsSettings](https://github.com/lomigmegard/akka-http-cors/blob/java-support/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/settings/CorsSettings.scala) can access Java APis and Scala APIs in the same time. I mean I can access maxAge and getMaxAge both. Do you think it's a good idea to leave like that? 