### PR TITLE
added check for chrome

### DIFF
--- a/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/CorsDirectives.scala
+++ b/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/CorsDirectives.scala
@@ -112,7 +112,7 @@ trait CorsDirectives {
               reject(CorsRejection(invalidOrigin, invalidMethod, invalidHeaders))
           }
 
-        case (_, Some(origins), None) if origins.nonEmpty ⇒
+        case (_, Some(origins), None) if origins.nonEmpty || header[Origin].head.value() == "null" ⇒
           // Case 2: actual CORS request
 
           val decorate: CorsDecorate = CorsDecorate.CorsRequest(origins)


### PR DESCRIPTION
Chrome does in some cases (afaik when redirecting further to itself on the cross-site-host, which is often a case with OpenID e.g. ) issue an ```Origin: null``` and checks the response accordingly. 

Akka HTTP header abstraction ignores those entries even though their valid. By explicitly checking things seem to work just fine.