### PR TITLE
Add Automatic-Module-Name for Java 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: scala
-jdk: oraclejdk8
 sudo: false
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+  - oraclejdk10
 scala:
-  - 2.12.5
-  - 2.11.11
+  - 2.12.6
+  - 2.11.12
   - 2.13.0-M3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.1 (unreleased)
 
+  - Java 9: add `Automatic-Module-Name: ch.megard.akka.http.cors` in the `MANIFEST.MF` (#35).
   - Update akka-http to 10.1.1.
   - Update Scala to 2.12.6.
 

--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,12 @@ lazy val `akka-http-cors` = project.
   settings(commonSettings: _*).
   settings(publishSettings: _*).
   settings(
+
+    // Java 9 Automatic-Module-Name (http://openjdk.java.net/projects/jigsaw/spec/issues/#AutomaticModuleNames)
+    packageOptions in (Compile, packageBin) += Package.ManifestAttributes(
+      "Automatic-Module-Name" -> "ch.megard.akka.http.cors"
+    ),
+
     libraryDependencies += "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
     libraryDependencies += "com.typesafe.akka" %% "akka-stream" % akkaVersion % "provided",
     libraryDependencies += "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % "test",


### PR DESCRIPTION
Fix #35

New `MANIFEST.MF`: 
```
scala-2.12 git:feature/java9 ❯ unzip -q -c akka-http-cors_2.12-0.3.1-SNAPSHOT.jar META-INF/MANIFEST.MF                                                      ✚
Manifest-Version: 1.0
Implementation-Title: akka-http-cors
Automatic-Module-Name: ch.megard.akka.http.cors
Implementation-Version: 0.3.1-SNAPSHOT
Specification-Vendor: ch.megard
Specification-Title: akka-http-cors
Implementation-Vendor-Id: ch.megard
Specification-Version: 0.3.1-SNAPSHOT
Implementation-Vendor: ch.megard
```

