### PR TITLE
Support `Origin: null` in preflight requests

### DIFF
--- a/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/CorsDirectives.scala
+++ b/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/CorsDirectives.scala
@@ -76,7 +76,7 @@ trait CorsDirectives {
       import request._
 
       (method, header[Origin].map(_.origins), header[`Access-Control-Request-Method`].map(_.method)) match {
-        case (OPTIONS, Some(origins), Some(requestMethod)) if origins.lengthCompare(1) == 0 ⇒
+        case (OPTIONS, Some(origins), Some(requestMethod)) if origins.lengthCompare(1) <= 0 ⇒
           // Case 1: pre-flight CORS request
 
           val headers = header[`Access-Control-Request-Headers`].map(_.headers).getOrElse(Seq.empty)


### PR DESCRIPTION
It looks like preflight requests with Origin: null are rejected - in my case, an OpenAPI page generated in IntelliJ as file:/// to use for testing.

It seems that we accept actual requests with Origin: null since #32, is there any reason not to also do so for preflight requests? Perhaps this was the problem @ShuiShengYe had per the #32 comments.

Another option could be to add explicit config to allow Origin: null in this case (e.g. that could be enabled in test scope), although with `allowed-origins = "*"` we are already fairly permissive.

Fix #43 