### PR TITLE
Support subdomain wildcard in allowed origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## (unreleased)
+
+  - Support subdomain wildcard matcher in allowed origins (#25).
+
 ## 0.3.4 (2019-01-17)
 
   - Cross compile with Scala 2.13.0-M5 (#40).

--- a/akka-http-cors/src/main/java/ch/megard/akka/http/cors/javadsl/model/HttpOriginMatcher.java
+++ b/akka-http-cors/src/main/java/ch/megard/akka/http/cors/javadsl/model/HttpOriginMatcher.java
@@ -1,0 +1,21 @@
+package ch.megard.akka.http.cors.javadsl.model;
+
+import akka.http.impl.util.Util;
+import akka.http.javadsl.model.headers.HttpOrigin;
+import ch.megard.akka.http.cors.scaladsl.model.HttpOriginMatcher$;
+
+public abstract class HttpOriginMatcher {
+
+    public abstract boolean matches(HttpOrigin origin);
+
+    public static HttpOriginMatcher ALL = ch.megard.akka.http.cors.scaladsl.model.HttpOriginMatcher.$times$.MODULE$;
+
+    public static HttpOriginMatcher create(HttpOrigin... origins) {
+        return HttpOriginMatcher$.MODULE$.apply(Util.<HttpOrigin, akka.http.scaladsl.model.headers.HttpOrigin>convertArray(origins));
+    }
+
+    public static HttpOriginMatcher strict(HttpOrigin... origins) {
+        return HttpOriginMatcher$.MODULE$.strict(Util.<HttpOrigin, akka.http.scaladsl.model.headers.HttpOrigin>convertArray(origins));
+    }
+
+}

--- a/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/javadsl/settings/CorsSettings.scala
+++ b/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/javadsl/settings/CorsSettings.scala
@@ -5,8 +5,7 @@ import java.util.Optional
 import akka.actor.ActorSystem
 import akka.annotation.DoNotInherit
 import akka.http.javadsl.model.HttpMethod
-import akka.http.javadsl.model.headers.HttpOriginRange
-import ch.megard.akka.http.cors.javadsl.model.HttpHeaderRange
+import ch.megard.akka.http.cors.javadsl.model.{HttpHeaderRange, HttpOriginMatcher}
 import ch.megard.akka.http.cors.scaladsl
 import ch.megard.akka.http.cors.scaladsl.settings.CorsSettingsImpl
 import com.typesafe.config.Config
@@ -19,7 +18,7 @@ abstract class CorsSettings { self: CorsSettingsImpl ⇒
 
   def getAllowGenericHttpRequests: Boolean
   def getAllowCredentials: Boolean
-  def getAllowedOrigins: HttpOriginRange
+  def getAllowedOrigins: HttpOriginMatcher
   def getAllowedHeaders: HttpHeaderRange
   def getAllowedMethods: java.lang.Iterable[HttpMethod]
   def getExposedHeaders: java.lang.Iterable[String]
@@ -27,7 +26,7 @@ abstract class CorsSettings { self: CorsSettingsImpl ⇒
 
   def withAllowGenericHttpRequests(newValue: Boolean): CorsSettings
   def withAllowCredentials(newValue: Boolean): CorsSettings
-  def withAllowedOrigins(newValue: HttpOriginRange): CorsSettings
+  def withAllowedOrigins(newValue: HttpOriginMatcher): CorsSettings
   def withAllowedHeaders(newValue: HttpHeaderRange): CorsSettings
   def withAllowedMethods(newValue: java.lang.Iterable[HttpMethod]): CorsSettings
   def withExposedHeaders(newValue: java.lang.Iterable[String]): CorsSettings

--- a/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/CorsDirectives.scala
+++ b/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/CorsDirectives.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.{HttpHeader, HttpMethod, HttpResponse, StatusCodes}
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.directives._
+import ch.megard.akka.http.cors.scaladsl.model.HttpOriginMatcher
 import ch.megard.akka.http.cors.scaladsl.settings.CorsSettings
 
 import scala.collection.immutable.Seq
@@ -48,7 +49,7 @@ trait CorsDirectives {
 
     /** Return the invalid origins, or `None` if one is valid. */
     def validateOrigins(origins: Seq[HttpOrigin]): Option[CorsRejection.Cause] =
-      if (allowedOrigins == HttpOriginRange.* || origins.exists(allowedOrigins.matches)) {
+      if (allowedOrigins == HttpOriginMatcher.* || origins.exists(allowedOrigins.matches)) {
         None
       } else {
         Some(CorsRejection.InvalidOrigin(origins))

--- a/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/model/HttpHeaderRange.scala
+++ b/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/model/HttpHeaderRange.scala
@@ -15,7 +15,7 @@ object HttpHeaderRange {
   }
 
   final case class Default(headers: Seq[String]) extends HttpHeaderRange {
-    val lowercaseHeaders = headers.map(_.toLowerCase(Locale.ROOT))
+    val lowercaseHeaders: Seq[String] = headers.map(_.toLowerCase(Locale.ROOT))
     def matches(header: String): Boolean = lowercaseHeaders contains header.toLowerCase(Locale.ROOT)
   }
 

--- a/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/model/HttpOriginMatcher.scala
+++ b/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/model/HttpOriginMatcher.scala
@@ -1,0 +1,76 @@
+package ch.megard.akka.http.cors.scaladsl.model
+
+import akka.http.javadsl.{model => jm}
+import akka.http.scaladsl.model.headers.HttpOrigin
+import ch.megard.akka.http.cors.javadsl
+
+import scala.collection.immutable.Seq
+
+
+/**
+  * [[HttpOrigin]] matcher.
+  */
+abstract class HttpOriginMatcher extends javadsl.model.HttpOriginMatcher {
+  def matches(origin: HttpOrigin): Boolean
+
+  /** Java API */
+  def matches(origin: jm.headers.HttpOrigin): Boolean = matches(origin.asInstanceOf[HttpOrigin])
+}
+
+object HttpOriginMatcher {
+  case object `*` extends HttpOriginMatcher {
+    def matches(origin: HttpOrigin) = true
+  }
+
+  final case class Default(origins: Seq[HttpOrigin]) extends HttpOriginMatcher {
+
+    private class StrictHostMatcher(origin: HttpOrigin) extends (HttpOrigin => Boolean) {
+      override def apply(origin: HttpOrigin): Boolean = origin == this.origin
+    }
+
+    private class WildcardHostMatcher(wildcardOrigin: HttpOrigin) extends (HttpOrigin => Boolean) {
+      private val suffix: String = wildcardOrigin.host.host.address.stripPrefix("*")
+      override def apply(origin: HttpOrigin): Boolean = {
+        origin.scheme == wildcardOrigin.scheme &&
+          origin.host.port == wildcardOrigin.host.port &&
+          origin.host.host.address.endsWith(suffix)
+      }
+    }
+
+    private val matchers: Seq[HttpOrigin => Boolean] = {
+      origins.map { origin =>
+        if (hasWildcard(origin)) new WildcardHostMatcher(origin) else new StrictHostMatcher(origin)
+      }
+    }
+
+    override def matches(origin: HttpOrigin): Boolean = matchers.exists(_ apply origin)
+    override def toString: String = origins.mkString(" ")
+  }
+
+  final case class Strict(origins: Seq[HttpOrigin]) extends HttpOriginMatcher {
+    override def matches(origin: HttpOrigin): Boolean = origins contains origin
+    override def toString: String = origins.mkString(" ")
+  }
+
+  private def hasWildcard(origin: HttpOrigin): Boolean =
+    origin.host.host.isNamedHost && origin.host.host.address.startsWith("*.")
+
+  /**
+    * Build a matcher that will accept any of the given origins.
+    * Wildcard in the hostname will not be interpreted.
+    */
+  def strict(origins: HttpOrigin*): HttpOriginMatcher =
+    Strict(origins.toList)
+
+  /**
+    * Build a matcher that will accept any of the given origins.
+    * Hostname starting with `*.` will match any sub-domain.
+    * The scheme and the port are always strictly matched.
+    */
+  def apply(origins: HttpOrigin*): HttpOriginMatcher = {
+    if (origins.exists(hasWildcard))
+      Default(origins.toList)
+    else
+      Strict(origins.toList)
+  }
+}

--- a/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/settings/CorsSettingsImpl.scala
+++ b/akka-http-cors/src/main/scala/ch/megard/akka/http/cors/scaladsl/settings/CorsSettingsImpl.scala
@@ -2,7 +2,7 @@ package ch.megard.akka.http.cors.scaladsl.settings
 
 import akka.http.scaladsl.model.{HttpHeader, HttpMethod}
 import akka.http.scaladsl.model.headers._
-import ch.megard.akka.http.cors.scaladsl.model.HttpHeaderRange
+import ch.megard.akka.http.cors.scaladsl.model.{HttpHeaderRange, HttpOriginMatcher}
 
 import scala.collection.immutable.Seq
 
@@ -10,7 +10,7 @@ import scala.collection.immutable.Seq
 private[akka] final case class CorsSettingsImpl(
     allowGenericHttpRequests: Boolean,
     allowCredentials: Boolean,
-    allowedOrigins: HttpOriginRange,
+    allowedOrigins: HttpOriginMatcher,
     allowedHeaders: HttpHeaderRange,
     allowedMethods: Seq[HttpMethod],
     exposedHeaders: Seq[String],
@@ -45,7 +45,7 @@ private[akka] final case class CorsSettingsImpl(
     }
 
   private def accessControlAllowOrigin(origins: Seq[HttpOrigin]): `Access-Control-Allow-Origin` =
-    if (allowedOrigins == HttpOriginRange.* && !allowCredentials)
+    if (allowedOrigins == HttpOriginMatcher.* && !allowCredentials)
       `Access-Control-Allow-Origin`.*
     else
       `Access-Control-Allow-Origin`.forRange(HttpOriginRange.Default(origins))

--- a/akka-http-cors/src/test/scala/ch/megard/akka/http/cors/scaladsl/model/HttpOriginMatcherSpec.scala
+++ b/akka-http-cors/src/test/scala/ch/megard/akka/http/cors/scaladsl/model/HttpOriginMatcherSpec.scala
@@ -1,0 +1,112 @@
+package ch.megard.akka.http.cors.scaladsl.model
+
+import akka.http.scaladsl.model.headers.HttpOrigin
+import org.scalatest.{Inspectors, Matchers, WordSpec}
+
+class HttpOriginMatcherSpec extends WordSpec with Matchers with Inspectors {
+
+
+  "The `*` matcher" should {
+    "match any Origin" in {
+      val origins = Seq(
+        "http://localhost",
+        "http://192.168.1.1",
+        "http://test.com",
+        "http://test.com:8080",
+        "https://test.com",
+        "https://test.com:4433"
+      ).map(HttpOrigin.apply)
+
+      forAll(origins) { o =>
+        HttpOriginMatcher.*.matches(o) shouldBe true
+      }
+    }
+
+    "be printed as `*`" in {
+      HttpOriginMatcher.*.toString shouldBe "*"
+    }
+  }
+
+  "The strict() method" should {
+    "build a strict matcher, comparing exactly the origins" in {
+      val positives = Seq(
+        "http://localhost",
+        "http://test.com",
+        "https://test.ch:12345",
+        "https://*.test.uk.co"
+      ).map(HttpOrigin.apply)
+
+      val negatives = Seq(
+        "http://localhost:80",
+        "https://localhost",
+        "http://test.com:8080",
+        "https://test.ch",
+        "https://abc.test.uk.co"
+      ).map(HttpOrigin.apply)
+
+      val matcher = HttpOriginMatcher.strict(positives: _*)
+
+      forAll(positives) { o =>
+        matcher.matches(o) shouldBe true
+      }
+
+      forAll(negatives) { o =>
+        matcher.matches(o) shouldBe false
+      }
+    }
+
+    "build a matcher with a toString() method that is a valid range" in {
+      val matcher = HttpOriginMatcher(Seq("http://test.com", "https://test.ch:12345").map(HttpOrigin.apply): _*)
+      matcher.toString shouldBe "http://test.com https://test.ch:12345"
+    }
+  }
+
+  "The apply() method" should {
+    "build a matcher accepting sub-domains with wildcards" in {
+
+      val matcher = HttpOriginMatcher(
+        Seq(
+          "http://test.com",
+          "https://test.ch:12345",
+          "https://*.test.uk.co",
+          "http://*.abc.com:8080",
+          "http://*abc.com", // Must start with `*.`
+          "http://abc.*.middle.com" // The wildcard can't be in the middle
+        ).map(HttpOrigin.apply): _*
+      )
+
+      val positives = Seq(
+        "http://test.com",
+        "https://test.ch:12345",
+        "https://sub.test.uk.co",
+        "https://sub1.sub2.test.uk.co",
+        "http://sub.abc.com:8080"
+      ).map(HttpOrigin.apply)
+
+      val negatives = Seq(
+        "http://test.com:8080",
+        "http://sub.test.uk.co", // must compare the scheme
+        "http://sub.abc.com", // must compare the port
+        "http://abc.test.com", // no wildcard
+        "http://sub.abc.com",
+        "http://subabc.com",
+        "http://abc.sub.middle.com",
+        "http://abc.middle.com"
+      ).map(HttpOrigin.apply)
+
+      forAll(positives) { o =>
+        matcher.matches(o) shouldBe true
+      }
+
+      forAll(negatives) { o =>
+        matcher.matches(o) shouldBe false
+      }
+    }
+
+    "build a matcher with a toString() method that is a valid range" in {
+      val matcher = HttpOriginMatcher(Seq("http://test.com", "https://*.test.ch:12345").map(HttpOrigin.apply): _*)
+      matcher.toString shouldBe "http://test.com https://*.test.ch:12345"
+    }
+  }
+
+}


### PR DESCRIPTION
Close #25.

*Breaking changes*: 
- Replace HttpOriginRange by HttpOriginMatcher in the settings.

Transparent changes if reading settings from the configuration file.